### PR TITLE
Added block based waitForStatus:timeout: method

### DIFF
--- a/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.h
+++ b/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.h
@@ -9,15 +9,13 @@
 
 #import <XCTest/XCTest.h>
 
-
-enum {
+typedef NS_ENUM(NSUInteger, XCTAsyncTestCaseStatus) {
     XCTAsyncTestCaseStatusUnknown = 0,
     XCTAsyncTestCaseStatusWaiting,
     XCTAsyncTestCaseStatusSucceeded,
     XCTAsyncTestCaseStatusFailed,
     XCTAsyncTestCaseStatusCancelled,
 };
-typedef NSUInteger XCTAsyncTestCaseStatus;
 
 
 @interface XCTestCase (AsyncTesting)
@@ -25,5 +23,5 @@ typedef NSUInteger XCTAsyncTestCaseStatus;
 - (void)waitForStatus:(XCTAsyncTestCaseStatus)status timeout:(NSTimeInterval)timeout;
 - (void)waitForTimeout:(NSTimeInterval)timeout;
 - (void)notify:(XCTAsyncTestCaseStatus)status;
-
+-(void)waitForStatus:(XCTAsyncTestCaseStatus)expectedStatus timeout:(NSTimeInterval)timeout withBlock:(void(^)(void))block;
 @end

--- a/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.m
+++ b/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.m
@@ -10,7 +10,7 @@
 #import "XCTestCase+AsyncTesting.h"
 #import "objc/runtime.h"
 
-static void *kLoopUntil_Key = "LoopUntil_Key";
+//static void *kLoopUntil_Key = "LoopUntil_Key";
 static void *kNotified_Key = "kNotified_Key";
 static void *kNotifiedStatus_Key = "kNotifiedStatus_Key";
 static void *kExpectedStatus_Key = "kExpectedStatus_Key";
@@ -18,21 +18,27 @@ static void *kExpectedStatus_Key = "kExpectedStatus_Key";
 @implementation XCTestCase (AsyncTesting)
 
 #pragma mark - Public
-
+-(void)waitForStatus:(XCTAsyncTestCaseStatus)expectedStatus timeout:(NSTimeInterval)timeout withBlock:(void(^)(void))block {
+    self.notified = NO;
+    self.expectedStatus = expectedStatus;
+    if (block) {
+        block();
+        NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:timeout];
+        [self waitUntilDate:loopUntil];
+        XCTAssertEqual(self.notifiedStatus, self.expectedStatus, @"Returned status %i did not match expected status %i", self.notifiedStatus, self.expectedStatus);
+    }
+    else {
+        XCTFail(@"No testing block to perform");
+    }
+}
 
 - (void)waitForStatus:(XCTAsyncTestCaseStatus)status timeout:(NSTimeInterval)timeout
 {
     self.notified = NO;
     self.expectedStatus = status;
-    self.loopUntil = [NSDate dateWithTimeIntervalSinceNow:timeout];
-    
-    NSDate *dt = [NSDate dateWithTimeIntervalSinceNow:0.1];
-    while (!self.notified && [self.loopUntil timeIntervalSinceNow] > 0) {
-        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
-                                 beforeDate:dt];
-        dt = [NSDate dateWithTimeIntervalSinceNow:0.1];
-    }
-    
+    NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:timeout];
+    [self waitUntilDate:loopUntil];
+
     // Only assert when notified. Do not assert when timed out
     // Fail if not notified
     if (self.notified) {
@@ -42,18 +48,21 @@ static void *kExpectedStatus_Key = "kExpectedStatus_Key";
     }
 }
 
-- (void)waitForTimeout:(NSTimeInterval)timeout
-{
-    self.notified = NO;
-    self.expectedStatus = XCTAsyncTestCaseStatusUnknown;
-    self.loopUntil = [NSDate dateWithTimeIntervalSinceNow:timeout];
-    
+-(void)waitUntilDate:(NSDate *)date {
     NSDate *dt = [NSDate dateWithTimeIntervalSinceNow:0.1];
-    while (!self.notified && [self.loopUntil timeIntervalSinceNow] > 0) {
+    while (!self.notified && [date timeIntervalSinceNow] > 0) {
         [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
                                  beforeDate:dt];
         dt = [NSDate dateWithTimeIntervalSinceNow:0.1];
     }
+}
+
+- (void)waitForTimeout:(NSTimeInterval)timeout
+{
+    self.notified = NO;
+    self.expectedStatus = XCTAsyncTestCaseStatusUnknown;
+    NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:timeout];
+    [self waitUntilDate:loopUntil];
 }
 
 - (void)notify:(XCTAsyncTestCaseStatus)status
@@ -77,17 +86,6 @@ static void *kExpectedStatus_Key = "kExpectedStatus_Key";
 }
 
 #pragma mark - Property Implementations -
-
-- (NSDate*) loopUntil
-{
-    return [self getAssociatedObject:kLoopUntil_Key];
-}
-
-- (void) setLoopUntil:(NSDate*)value
-{
-    [self setAssociatedObject:value key:kLoopUntil_Key];
-}
-
 - (BOOL) notified
 {
     NSNumber *valueNumber = [self getAssociatedObject:kNotified_Key];

--- a/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.m
+++ b/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.m
@@ -10,7 +10,6 @@
 #import "XCTestCase+AsyncTesting.h"
 #import "objc/runtime.h"
 
-//static void *kLoopUntil_Key = "LoopUntil_Key";
 static void *kNotified_Key = "kNotified_Key";
 static void *kNotifiedStatus_Key = "kNotifiedStatus_Key";
 static void *kExpectedStatus_Key = "kExpectedStatus_Key";

--- a/AsyncXCTestingKit/AsyncXCTestingKitTests/AsyncXCTestingKitTests.m
+++ b/AsyncXCTestingKit/AsyncXCTestingKitTests/AsyncXCTestingKitTests.m
@@ -85,6 +85,7 @@
     NSLog(@"Test Finished!");
 }
 
+
 - (void)testAsyncWithBlocks200_EXPECT_FAIL
 {
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.google.com"]];
@@ -160,9 +161,9 @@
 - (void)testAsyncMainQueue
 {
     /*
-     
+
      This is the preferred way if you're using iOS SDK 4 or above.
-     
+
      Test Case '-[AsyncSenTestingKitTests testAsyncMainQueue]' started.
      2012-03-17 16:27:49.974 otest[939:7b03] -[AsyncSenTestingKitTests setUp]
      2012-03-17 16:27:49.975 otest[939:7b03] Wait loop start
@@ -170,7 +171,7 @@
      2012-03-17 16:27:51.977 otest[939:7b03] Wait loop finished
      2012-03-17 16:27:51.979 otest[939:7b03] -[AsyncSenTestingKitTests tearDown]
      Test Case '-[AsyncSenTestingKitTests testAsyncMainQueue]' passed (2.007 seconds).
-     
+
      */
     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 2.0 * NSEC_PER_SEC);
     dispatch_after(popTime, dispatch_get_main_queue(), ^{
@@ -179,12 +180,13 @@
     [self waitForStatus:XCTAsyncTestCaseStatusSucceeded timeout:5.0];
 }
 
+
 - (void)testAsyncPerformSelector
 {
     /*
-     
+
      Using -performSelector:withObject:afterDelay is no longer recommended as the test has to wait until timeout, like below:
-     
+
      Test Case '-[AsyncSenTestingKitTests testAsyncPerformSelector]' started.
      2012-03-17 16:27:51.980 otest[939:7b03] -[AsyncSenTestingKitTests setUp]
      2012-03-17 16:27:51.981 otest[939:7b03] Wait loop start
@@ -192,10 +194,10 @@
      2012-03-17 16:27:56.983 otest[939:7b03] Wait loop finished
      2012-03-17 16:27:56.984 otest[939:7b03] -[AsyncSenTestingKitTests tearDown]
      Test Case '-[AsyncSenTestingKitTests testAsyncPerformSelector]' passed (5.004 seconds).
-     
+
      This is because the -performSelector:withObject:afterDelay method internally uses timer. Timers are not considered to be
      the input sources thus -runMode:beforeDate: doesn't return.
-     
+
      */
     [self performSelector:@selector(___internal___testAsyncPerformSelector) withObject:nil afterDelay:2.0];
     [self waitForStatus:XCTAsyncTestCaseStatusSucceeded timeout:5.0];
@@ -206,5 +208,248 @@
     [self notify:XCTAsyncTestCaseStatusSucceeded];
 }
 
+#pragma mark - Tests for Block wait, replicates the tests for the existing waitForStatus:timeout:
+
+- (void)testAsyncTimeoutsProperlyUsingBlock_EXPECT_FAIL
+{
+    [self waitForStatus:XCTAsyncTestCaseStatusSucceeded timeout:3.0 withBlock:nil];
+}
+
+
+- (void)testAsyncWithDelegateUsingBlock
+{
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.google.com"]];
+    [self waitForStatus:XCTAsyncTestCaseStatusSucceeded timeout:10.0 withBlock:^{
+        [NSURLConnection connectionWithRequest:request delegate:self];
+    }];
+}
+
+- (void)testAsyncWithBlocks200UsingBlock
+{
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.google.com"]];
+    [self waitForStatus:XCTAsyncTestCaseStatusSucceeded timeout:10.0 withBlock:^{
+        [NSURLConnection sendAsynchronousRequest:request
+                                           queue:[NSOperationQueue mainQueue]
+                               completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+                                   if (error) {
+                                       NSLog(@"Request failed with error: %@", error);
+                                       [self notify:XCTAsyncTestCaseStatusFailed];
+                                       return;
+                                   }
+                                   NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+                                   XCTAssertEqual([httpResponse statusCode], 200, @"");
+                                   NSLog(@"Request Finished!");
+                                   [self notify:XCTAsyncTestCaseStatusSucceeded];
+                               }];
+    }];
+}
+
+- (void)testAsyncWithBlocks200UsingBlock_EXPECT_FAIL
+{
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.google.com"]];
+    [self waitForStatus:XCTAsyncTestCaseStatusSucceeded timeout:10 withBlock:^{
+
+        [NSURLConnection sendAsynchronousRequest:request
+                                           queue:[NSOperationQueue mainQueue]
+                               completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+                                   if (error) {
+                                       NSLog(@"Request failed with error: %@", error);
+                                       [self notify:XCTAsyncTestCaseStatusFailed];
+                                       return;
+                                   }
+                                   NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+                                   XCTAssertEqual([httpResponse statusCode], 404, @"Expected Fail");
+                                   NSLog(@"Request Finished!");
+                                   [self notify:XCTAsyncTestCaseStatusSucceeded];
+                               }];
+    }];
+}
+
+- (void)testAsyncWithBlocksStatusDoesntMatchUsingBlock_EXPECT_FAIL
+{
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.google.com"]];
+    [self waitForStatus:XCTAsyncTestCaseStatusSucceeded timeout:10.0 withBlock:^{
+
+        [NSURLConnection sendAsynchronousRequest:request
+                                           queue:[NSOperationQueue mainQueue]
+                               completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+                                   if (error) {
+                                       NSLog(@"Request failed with error: %@", error);
+                                       [self notify:XCTAsyncTestCaseStatusFailed];
+                                       return;
+                                   }
+                                   NSLog(@"Request Finished!");
+                                   [self notify:XCTAsyncTestCaseStatusCancelled];
+                               }];
+    }];
+}
+
+- (void)testAsyncWithBlocksErrorUsingBlock
+{
+    //NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.there_should_be_no_such_domain_in_the_world.org"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"file://tester"]];
+    [self waitForStatus:XCTAsyncTestCaseStatusFailed timeout:10.0 withBlock:^{
+        [NSURLConnection sendAsynchronousRequest:request
+                                           queue:[NSOperationQueue mainQueue]
+                               completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+                                   if (error) {
+                                       NSLog(@"Request failed with error: %@", error);
+                                       [self notify:XCTAsyncTestCaseStatusFailed];
+                                       return;
+                                   }
+                                   XCTFail(@"Must fail before this statement");
+                               }];
+    }];
+}
+
+- (void)testAsyncWithBlocksErrorUsingBlock_EXPECT_FAIL
+{
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.there_should_be_no_such_domain_in_the_world.org"]];
+    [self waitForStatus:XCTAsyncTestCaseStatusFailed timeout:5.0 withBlock:^{
+        [NSURLConnection sendAsynchronousRequest:request
+                                           queue:[NSOperationQueue mainQueue]
+                               completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+                                   // DOES fail on events while not notifying
+                                   // This results in waiting until timeout
+                                   XCTFail(@"Must fail before this statement");
+                               }];
+    }];
+}
+
+- (void)testAsyncMainQueueUsingBlock
+{
+    /*
+
+     This is the preferred way if you're using iOS SDK 4 or above.
+
+     Test Case '-[AsyncSenTestingKitTests testAsyncMainQueue]' started.
+     2012-03-17 16:27:49.974 otest[939:7b03] -[AsyncSenTestingKitTests setUp]
+     2012-03-17 16:27:49.975 otest[939:7b03] Wait loop start
+     2012-03-17 16:27:51.976 otest[939:7b03] Notified
+     2012-03-17 16:27:51.977 otest[939:7b03] Wait loop finished
+     2012-03-17 16:27:51.979 otest[939:7b03] -[AsyncSenTestingKitTests tearDown]
+     Test Case '-[AsyncSenTestingKitTests testAsyncMainQueue]' passed (2.007 seconds).
+
+     */
+    [self waitForStatus:XCTAsyncTestCaseStatusSucceeded timeout:5.0 withBlock:^{
+        dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 2.0 * NSEC_PER_SEC);
+        dispatch_after(popTime, dispatch_get_main_queue(), ^{
+            [self notify:XCTAsyncTestCaseStatusSucceeded];
+        });
+    }];
+}
+
+
+- (void)testAsyncPerformSelectorUsingBlock
+{
+    /*
+
+     Using -performSelector:withObject:afterDelay is no longer recommended as the test has to wait until timeout, like below:
+
+     Test Case '-[AsyncSenTestingKitTests testAsyncPerformSelector]' started.
+     2012-03-17 16:27:51.980 otest[939:7b03] -[AsyncSenTestingKitTests setUp]
+     2012-03-17 16:27:51.981 otest[939:7b03] Wait loop start
+     2012-03-17 16:27:53.982 otest[939:7b03] Notified
+     2012-03-17 16:27:56.983 otest[939:7b03] Wait loop finished
+     2012-03-17 16:27:56.984 otest[939:7b03] -[AsyncSenTestingKitTests tearDown]
+     Test Case '-[AsyncSenTestingKitTests testAsyncPerformSelector]' passed (5.004 seconds).
+
+     This is because the -performSelector:withObject:afterDelay method internally uses timer. Timers are not considered to be
+     the input sources thus -runMode:beforeDate: doesn't return.
+
+     */
+    [self waitForStatus:XCTAsyncTestCaseStatusSucceeded timeout:5.0 withBlock:^{
+        [self performSelector:@selector(___internal___testAsyncPerformSelector) withObject:nil afterDelay:2.0];
+    }];
+}
+
+#pragma mark - Test Cases Where waitForStatus:timeout: will fail but waitForStatus:timeout:withBlock: does not
+/*
+ The disabled "Expect Fail" tests below are here just for proof that the block based waitForStatus: method is better since it original method can cause unexpected failures where the correct status is set, but the notified property was reset to NO after the status had already been set.  This can happen when testing a block bacsed method that may or may not be asynchronous, but sets the status before the waitForStatus:timeout: method to be called.  The waitForStatus:timeout:withBlock: method works everywhere the waitForStatus:timeout method does and more.  And it has the benefit of being more readable.
+ */
+-(void)blockMethodThatReturnsImmediately:(void(^)(void))block {
+    if (block) {
+        block();
+    }
+}
+
+-(void)testSeeminglyAsyncBlockMethodThatReturnsImmediatelyStillReturnsSuccess {
+    [self waitForStatus:XCTAsyncTestCaseStatusSucceeded timeout:2.0 withBlock:^{
+        [self blockMethodThatReturnsImmediately:^{
+            [self notify:XCTAsyncTestCaseStatusSucceeded];
+        }];
+    }];
+}
+
+-(void)testSeeminglyAsyncBlockMethodThatReturnsImmediatelyStillReturnsSuccess_EXPECT_FAIL {
+    [self blockMethodThatReturnsImmediately:^{
+        [self notify:XCTAsyncTestCaseStatusSucceeded];
+    }];
+    [self waitForStatus:XCTAsyncTestCaseStatusSucceeded timeout:2.0];
+}
+
+
+-(void)testSeeminglyAsyncBlockMethodThatReturnsImmediatelyStillReturnsFailed {
+    [self waitForStatus:XCTAsyncTestCaseStatusFailed timeout:2.0 withBlock:^{
+        [self blockMethodThatReturnsImmediately:^{
+            [self notify:XCTAsyncTestCaseStatusFailed];
+        }];
+    }];
+}
+
+-(void)testSeeminglyAsyncBlockMethodThatReturnsImmediatelyStillReturnsFailed_EXPECT_FAIL {
+    [self blockMethodThatReturnsImmediately:^{
+        [self notify:XCTAsyncTestCaseStatusFailed];
+    }];
+    [self waitForStatus:XCTAsyncTestCaseStatusFailed timeout:2.0];
+}
+
+
+-(void)testSeeminglyAsyncBlockMethodThatReturnsImmediatelyStillReturnsCanceled {
+    [self waitForStatus:XCTAsyncTestCaseStatusCancelled timeout:2.0 withBlock:^{
+        [self blockMethodThatReturnsImmediately:^{
+            [self notify:XCTAsyncTestCaseStatusCancelled];
+        }];
+    }];
+}
+
+-(void)testSeeminglyAsyncBlockMethodThatReturnsImmediatelyStillReturnsCanceled_EXPECT_FAIL {
+    [self blockMethodThatReturnsImmediately:^{
+        [self notify:XCTAsyncTestCaseStatusCancelled];
+    }];
+    [self waitForStatus:XCTAsyncTestCaseStatusCancelled timeout:2.0];
+}
+
+
+-(void)testSeeminglyAsyncBlockMethodThatReturnsImmediatelyStillReturnsWaiting {
+    [self waitForStatus:XCTAsyncTestCaseStatusWaiting timeout:2.0 withBlock:^{
+        [self blockMethodThatReturnsImmediately:^{
+            [self notify:XCTAsyncTestCaseStatusWaiting];
+        }];
+    }];
+}
+
+-(void)testSeeminglyAsyncBlockMethodThatReturnsImmediatelyStillReturnsWaiting_EXPECT_FAIL {
+    [self blockMethodThatReturnsImmediately:^{
+        [self notify:XCTAsyncTestCaseStatusWaiting];
+    }];
+    [self waitForStatus:XCTAsyncTestCaseStatusWaiting timeout:2.0];
+}
+
+
+-(void)testSeeminglyAsyncBlockMethodThatReturnsImmediatelyStillReturnsUnkown {
+    [self waitForStatus:XCTAsyncTestCaseStatusUnknown timeout:2.0 withBlock:^{
+        [self blockMethodThatReturnsImmediately:^{
+            [self notify:XCTAsyncTestCaseStatusUnknown];
+        }];
+    }];
+}
+
+-(void)testSeeminglyAsyncBlockMethodThatReturnsImmediatelyStillReturnsUnknown_EXPECT_FAIL {
+    [self blockMethodThatReturnsImmediately:^{
+        [self notify:XCTAsyncTestCaseStatusUnknown];
+    }];
+    [self waitForStatus:XCTAsyncTestCaseStatusUnknown timeout:2.0];
+}
 
 @end


### PR DESCRIPTION
I added a waitForStatus:timeout:withBlock: method in order to fix an issue that caused tests to timeout when the notify: method got called before waitForStatus:timeout: method for called.  The waitForStatus:timeout:withBlock: guarantees that the steps to test are called only _after_ the reset of the notified property to NO.  It also has a the benefit of making the test more readable since the waitForStatus step wraps the step you're waiting on.

``` obj-c
[self waitForStatus:XCTAsyncTestCaseStatusSucceeded timeout:2.0 withBlock:^{
    [self blockMethodThatReturnsImmediately:^{
        [self notify:XCTAsyncTestCaseStatusSucceeded];
    }];
}];
```

I added a set of test cases to show the block version works in all the same places the non-block version does.  I've also added new test cases that show where the block version works better.  There is a matching test for each that is disabled that shows the same test failing under the non-block version.

I also refactored the code use to wait because it was used in two places, I consolidated into on method.  The loopUntil associated object was not needed since the loopUntil date wasn't referred to anywhere outside the method, so I removed it.  I also changed the enum to use the NS_ENUM macro which makes things a little cleaner.
