### PR TITLE
added shorthand support

### DIFF
--- a/AsyncXCTestingKit/AsyncXCTestingKit/AsyncXCTestingKit-Prefix.pch
+++ b/AsyncXCTestingKit/AsyncXCTestingKit/AsyncXCTestingKit-Prefix.pch
@@ -7,3 +7,7 @@
 #ifdef __OBJC__
     #import <Foundation/Foundation.h>
 #endif
+
+#ifndef XAT_SHORTHAND
+#define XAT_SHORTHAND
+#endif

--- a/AsyncXCTestingKit/AsyncXCTestingKit/AsyncXCTestingKit-Prefix.pch
+++ b/AsyncXCTestingKit/AsyncXCTestingKit/AsyncXCTestingKit-Prefix.pch
@@ -8,6 +8,6 @@
     #import <Foundation/Foundation.h>
 #endif
 
-#ifndef XAT_SHORTHAND
-#define XAT_SHORTHAND
+#ifndef XCA_SHORTHAND
+#define XCA_SHORTHAND
 #endif

--- a/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.h
+++ b/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.h
@@ -19,16 +19,16 @@ typedef NS_ENUM(NSUInteger, XCTAsyncTestCaseStatus) {
 
 @interface XCTestCase (AsyncTesting)
 
-- (void)XAT_waitForTimeout:(NSTimeInterval)timeout;
-- (void)XAT_waitForStatus:(XCTAsyncTestCaseStatus)status timeout:(NSTimeInterval)timeout;
-- (void)XAT_waitForStatus:(XCTAsyncTestCaseStatus)expectedStatus timeout:(NSTimeInterval)timeout withBlock:(void(^)(void))block;
+- (void)XCA_waitForTimeout:(NSTimeInterval)timeout;
+- (void)XCA_waitForStatus:(XCTAsyncTestCaseStatus)status timeout:(NSTimeInterval)timeout;
+- (void)XCA_waitForStatus:(XCTAsyncTestCaseStatus)expectedStatus timeout:(NSTimeInterval)timeout withBlock:(void(^)(void))block;
 
-- (void)XAT_notify:(XCTAsyncTestCaseStatus)status;
-- (void)XAT_notify:(XCTAsyncTestCaseStatus)status withDelay:(NSTimeInterval)delay;
+- (void)XCA_notify:(XCTAsyncTestCaseStatus)status;
+- (void)XCA_notify:(XCTAsyncTestCaseStatus)status withDelay:(NSTimeInterval)delay;
 
 @end
 
-#ifdef XAT_SHORTHAND
+#ifdef XCA_SHORTHAND
 @interface XCTestCase (AsyncTestingShortHand)
 
 - (void)waitForTimeout:(NSTimeInterval)timeout;

--- a/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.h
+++ b/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.h
@@ -17,12 +17,26 @@ typedef NS_ENUM(NSUInteger, XCTAsyncTestCaseStatus) {
     XCTAsyncTestCaseStatusCancelled,
 };
 
-
 @interface XCTestCase (AsyncTesting)
 
-- (void)waitForStatus:(XCTAsyncTestCaseStatus)status timeout:(NSTimeInterval)timeout;
+- (void)XAT_waitForTimeout:(NSTimeInterval)timeout;
+- (void)XAT_waitForStatus:(XCTAsyncTestCaseStatus)status timeout:(NSTimeInterval)timeout;
+- (void)XAT_waitForStatus:(XCTAsyncTestCaseStatus)expectedStatus timeout:(NSTimeInterval)timeout withBlock:(void(^)(void))block;
+
+- (void)XAT_notify:(XCTAsyncTestCaseStatus)status;
+- (void)XAT_notify:(XCTAsyncTestCaseStatus)status withDelay:(NSTimeInterval)delay;
+
+@end
+
+#ifdef XAT_SHORTHAND
+@interface XCTestCase (AsyncTestingShortHand)
+
 - (void)waitForTimeout:(NSTimeInterval)timeout;
+- (void)waitForStatus:(XCTAsyncTestCaseStatus)status timeout:(NSTimeInterval)timeout;
+- (void)waitForStatus:(XCTAsyncTestCaseStatus)expectedStatus timeout:(NSTimeInterval)timeout withBlock:(void(^)(void))block;
+
 - (void)notify:(XCTAsyncTestCaseStatus)status;
 - (void)notify:(XCTAsyncTestCaseStatus)status withDelay:(NSTimeInterval)delay;
-- (void)waitForStatus:(XCTAsyncTestCaseStatus)expectedStatus timeout:(NSTimeInterval)timeout withBlock:(void(^)(void))block;
+
 @end
+#endif

--- a/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.m
+++ b/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.m
@@ -14,45 +14,128 @@ static void *kNotified_Key = "kNotified_Key";
 static void *kNotifiedStatus_Key = "kNotifiedStatus_Key";
 static void *kExpectedStatus_Key = "kExpectedStatus_Key";
 
+static NSString * const kXCTestCaseAsyncTestingCategoryMethodPrefix = @"XAT_";
+
 @implementation XCTestCase (AsyncTesting)
 
-#pragma mark - Public
-- (void)waitForStatus:(XCTAsyncTestCaseStatus)expectedStatus timeout:(NSTimeInterval)timeout withBlock:(void(^)(void))block {
-    NSParameterAssert(block);
-    
-    self.notified = NO;
-    self.expectedStatus = expectedStatus;
+// Big thanks to Saul Mora (https://github.com/casademora)
+// for the shorthand implementation of MagicalRecord (https://github.com/magicalpanda/MagicalRecord)
+#ifdef XAT_SHORTHAND
++ (void)load {
 
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        [self swizzleNeededMethods];
+    });
+
+}
+#endif
+
++ (void)swizzleNeededMethods {
+
+    SEL sourceSelector = @selector(resolveInstanceMethod:);
+    SEL targetSelector = @selector(XAT_resolveInstanceMethod:);
+    
+    Method sourceClassMethod = class_getClassMethod(self, sourceSelector);
+    Method targetClassMethod = class_getClassMethod(self, targetSelector);
+    
+    Class targetMetaClass = objc_getMetaClass([NSStringFromClass(self) cStringUsingEncoding:NSUTF8StringEncoding]);
+    
+    BOOL methodWasSuccessfullyAdded = class_addMethod(targetMetaClass, sourceSelector,
+                                                      method_getImplementation(targetClassMethod),
+                                                      method_getTypeEncoding(targetClassMethod));
+    
+    if (methodWasSuccessfullyAdded) {
+        
+        class_replaceMethod(targetMetaClass, targetSelector,
+                            method_getImplementation(sourceClassMethod),
+                            method_getTypeEncoding(sourceClassMethod));
+    }
+    
+}
+
++ (BOOL)XAT_resolveInstanceMethod:(SEL)originalSelector {
+    NSParameterAssert(originalSelector);
+    
+    BOOL instanceMethodWasResolved = [self XAT_resolveInstanceMethod:originalSelector];
+    if (!instanceMethodWasResolved) {
+        
+        instanceMethodWasResolved = [self addShorthandMethodForNonPrefixedMethod:self selector:originalSelector];
+    }
+    
+    return instanceMethodWasResolved;
+}
+
+
++ (BOOL)addShorthandMethodForNonPrefixedMethod:(Class)class selector:(SEL)originalSelector {
+    NSParameterAssert(class);
+    NSParameterAssert(originalSelector);
+    
+    NSString *originalSelectorString = NSStringFromSelector(originalSelector);
+    //if ([originalSelectorString hasPrefix:@"_"] || [originalSelectorString hasPrefix:@"init"]) return NO;
+
+
+    
+    BOOL methodWasSuccessfullyAdded = NO;
+    if (![originalSelectorString hasPrefix: kXCTestCaseAsyncTestingCategoryMethodPrefix ]) {
+        
+        NSString *prefixedSelector = [kXCTestCaseAsyncTestingCategoryMethodPrefix stringByAppendingString:originalSelectorString];
+        Method existingMethod = class_getInstanceMethod(class, NSSelectorFromString(prefixedSelector));
+        
+        if (existingMethod) {
+            
+            methodWasSuccessfullyAdded = class_addMethod(class,
+                                                         originalSelector,
+                                                         method_getImplementation(existingMethod),
+                                                         method_getTypeEncoding(existingMethod));
+            
+        }
+    }
+    return methodWasSuccessfullyAdded;
+}
+
+
+#pragma mark - Public
+- (void)XAT_waitForStatus:(XCTAsyncTestCaseStatus)expectedStatus timeout:(NSTimeInterval)timeout withBlock:(void(^)(void))block {
+    NSParameterAssert(block);
+    NSParameterAssert(timeout > 0);
+
+    self._notified = NO;
+    self._expectedStatus = expectedStatus;
+    
     block();
     NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:timeout];
-    [self waitUntilDate:loopUntil];
+    [self XAT_waitUntilDate:loopUntil];
     
     // Only assert when notified. Do not assert when timed out
     // Fail if not notified
-    [self raiseExceptionIfNeeded];
-  
+    [self _raiseExceptionIfNeeded];
+    
 }
 
-- (void)waitForStatus:(XCTAsyncTestCaseStatus)status timeout:(NSTimeInterval)timeout {
-    self.notified = NO;
-    self.expectedStatus = status;
+- (void)XAT_waitForStatus:(XCTAsyncTestCaseStatus)status timeout:(NSTimeInterval)timeout {
+    NSParameterAssert(timeout > 0);
+    
+    self._notified = NO;
+    self._expectedStatus = status;
     NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:timeout];
-    [self waitUntilDate:loopUntil];
-
+    [self XAT_waitUntilDate:loopUntil];
+    
     // Only assert when notified. Do not assert when timed out
     // Fail if not notified
-    [self raiseExceptionIfNeeded];
+    [self _raiseExceptionIfNeeded];
 }
 
-- (void)raiseExceptionIfNeeded {
+- (void)_raiseExceptionIfNeeded {
     
     NSException *exception = nil;
-    if (self.notified) {
+    if (self._notified) {
         
-        if (self.notifiedStatus != self.expectedStatus) {
+        if (self._notifiedStatus != self._expectedStatus) {
             
             exception = [NSException exceptionWithName:@"ReturnStatusDidNotMatch"
-                                                reason:[NSString stringWithFormat:@"Returned status %lu did not match expected status %lu", self.notifiedStatus, self.expectedStatus]
+                                                reason:[NSString stringWithFormat:@"Returned status %lu did not match expected status %lu",
+                                                        self._notifiedStatus, self._expectedStatus]
                                               userInfo:nil];
         }
     } else {
@@ -60,94 +143,100 @@ static void *kExpectedStatus_Key = "kExpectedStatus_Key";
         exception = [NSException exceptionWithName:@"TimeOut"
                                             reason:@"Async test timed out."
                                           userInfo:nil];
-                
+        
     }
     
     [exception raise];
     
 }
 
-- (void)waitUntilDate:(NSDate *)date {
+- (void)XAT_waitUntilDate:(NSDate *)date {
+    NSParameterAssert(date);
+    NSParameterAssert([date compare: [NSDate date]] == NSOrderedDescending);
+    
     NSDate *dt = [NSDate dateWithTimeIntervalSinceNow:0.1];
-    while (!self.notified && [date timeIntervalSinceNow] > 0) {
+    while (!self._notified && [date timeIntervalSinceNow] > 0) {
         [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
                                  beforeDate:dt];
         dt = [NSDate dateWithTimeIntervalSinceNow:0.1];
     }
 }
 
-- (void)waitForTimeout:(NSTimeInterval)timeout
-{
-    self.notified = NO;
-    self.expectedStatus = XCTAsyncTestCaseStatusUnknown;
+- (void)XAT_waitForTimeout:(NSTimeInterval)timeout {
+    NSParameterAssert(timeout > 0);
+    
+    self._notified = NO;
+    self._expectedStatus = XCTAsyncTestCaseStatusUnknown;
     NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:timeout];
-    [self waitUntilDate:loopUntil];
+    [self XAT_waitUntilDate:loopUntil];
 }
 
-- (void)notify:(XCTAsyncTestCaseStatus)status
-{
-    self.notifiedStatus = status;
+- (void)XAT_notify:(XCTAsyncTestCaseStatus)status {
+    
+    self._notifiedStatus = status;
     // self.notified must be set at the last of this method
-    self.notified = YES;
+    self._notified = YES;
 }
 
-- (void)notify:(XCTAsyncTestCaseStatus)status withDelay:(NSTimeInterval)delay {
+- (void)XAT_notify:(XCTAsyncTestCaseStatus)status withDelay:(NSTimeInterval)delay {
+    NSParameterAssert(delay > 0);
 
     __weak typeof(self) weakSelf = self;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        [weakSelf notify:status];
+        [weakSelf XAT_notify:status];
     });
-
+    
 }
 
 #pragma nark - Object Association Helpers -
 
-- (void) setAssociatedObject:(id)anObject key:(void*)key
-{
+- (void)_setAssociatedObject:(id)anObject key:(void*)key {
+    NSParameterAssert(anObject);
+    
     objc_setAssociatedObject(self, key, anObject, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-- (id) getAssociatedObject:(void*)key
-{
+- (id)_getAssociatedObject:(void*)key {
+    
     id anObject = objc_getAssociatedObject(self, key);
     return anObject;
 }
 
 #pragma mark - Property Implementations -
-- (BOOL) notified
-{
-    NSNumber *valueNumber = [self getAssociatedObject:kNotified_Key];
+- (BOOL)_notified {
+    
+    NSNumber *valueNumber = [self _getAssociatedObject:kNotified_Key];
     return [valueNumber boolValue];
 }
 
-- (void) setNotified:(BOOL)value
-{
+- (void)set_notified:(BOOL)value {
+    
     NSNumber *valueNumber = [NSNumber numberWithBool:value];
-    [self setAssociatedObject:valueNumber key:kNotified_Key];
+    [self _setAssociatedObject:valueNumber key:kNotified_Key];
 }
 
-- (XCTAsyncTestCaseStatus) notifiedStatus
-{
-    NSNumber *valueNumber = [self getAssociatedObject:kNotifiedStatus_Key];
+- (XCTAsyncTestCaseStatus)_notifiedStatus {
+    
+    NSNumber *valueNumber = [self _getAssociatedObject:kNotifiedStatus_Key];
     return [valueNumber integerValue];
 }
 
-- (void) setNotifiedStatus:(XCTAsyncTestCaseStatus)value
-{
+- (void)set_notifiedStatus:(XCTAsyncTestCaseStatus)value {
+    
     NSNumber *valueNumber = [NSNumber numberWithUnsignedInteger:value];
-    [self setAssociatedObject:valueNumber key:kNotifiedStatus_Key];
+    [self _setAssociatedObject:valueNumber key:kNotifiedStatus_Key];
 }
 
-- (XCTAsyncTestCaseStatus) expectedStatus
-{
-    NSNumber *valueNumber = [self getAssociatedObject:kExpectedStatus_Key];
+- (XCTAsyncTestCaseStatus)_expectedStatus {
+    
+    NSNumber *valueNumber = [self _getAssociatedObject:kExpectedStatus_Key];
     return [valueNumber integerValue];
 }
 
-- (void) setExpectedStatus:(XCTAsyncTestCaseStatus)value
-{
+- (void)set_expectedStatus:(XCTAsyncTestCaseStatus)value {
+    
     NSNumber *valueNumber = [NSNumber numberWithUnsignedInteger:value];
-    [self setAssociatedObject:valueNumber key:kExpectedStatus_Key];
+    [self _setAssociatedObject:valueNumber key:kExpectedStatus_Key];
 }
 
 @end

--- a/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.m
+++ b/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.m
@@ -14,13 +14,13 @@ static void *kNotified_Key = "kNotified_Key";
 static void *kNotifiedStatus_Key = "kNotifiedStatus_Key";
 static void *kExpectedStatus_Key = "kExpectedStatus_Key";
 
-static NSString * const kXCTestCaseAsyncTestingCategoryMethodPrefix = @"XAT_";
+static NSString * const kXCTestCaseAsyncTestingCategoryMethodPrefix = @"XCA_";
 
 @implementation XCTestCase (AsyncTesting)
 
 // Big thanks to Saul Mora (https://github.com/casademora)
 // for the shorthand implementation of MagicalRecord (https://github.com/magicalpanda/MagicalRecord)
-#ifdef XAT_SHORTHAND
+#ifdef XCA_SHORTHAND
 + (void)load {
 
     static dispatch_once_t onceToken;
@@ -34,7 +34,7 @@ static NSString * const kXCTestCaseAsyncTestingCategoryMethodPrefix = @"XAT_";
 + (void)swizzleNeededMethods {
 
     SEL sourceSelector = @selector(resolveInstanceMethod:);
-    SEL targetSelector = @selector(XAT_resolveInstanceMethod:);
+    SEL targetSelector = @selector(XCA_resolveInstanceMethod:);
     
     Method sourceClassMethod = class_getClassMethod(self, sourceSelector);
     Method targetClassMethod = class_getClassMethod(self, targetSelector);
@@ -54,10 +54,10 @@ static NSString * const kXCTestCaseAsyncTestingCategoryMethodPrefix = @"XAT_";
     
 }
 
-+ (BOOL)XAT_resolveInstanceMethod:(SEL)originalSelector {
++ (BOOL)XCA_resolveInstanceMethod:(SEL)originalSelector {
     NSParameterAssert(originalSelector);
     
-    BOOL instanceMethodWasResolved = [self XAT_resolveInstanceMethod:originalSelector];
+    BOOL instanceMethodWasResolved = [self XCA_resolveInstanceMethod:originalSelector];
     if (!instanceMethodWasResolved) {
         
         instanceMethodWasResolved = [self addShorthandMethodForNonPrefixedMethod:self selector:originalSelector];
@@ -94,7 +94,7 @@ static NSString * const kXCTestCaseAsyncTestingCategoryMethodPrefix = @"XAT_";
 
 
 #pragma mark - Public
-- (void)XAT_waitForStatus:(XCTAsyncTestCaseStatus)expectedStatus timeout:(NSTimeInterval)timeout withBlock:(void(^)(void))block {
+- (void)XCA_waitForStatus:(XCTAsyncTestCaseStatus)expectedStatus timeout:(NSTimeInterval)timeout withBlock:(void(^)(void))block {
     NSParameterAssert(block);
     NSParameterAssert(timeout > 0);
 
@@ -103,7 +103,7 @@ static NSString * const kXCTestCaseAsyncTestingCategoryMethodPrefix = @"XAT_";
     
     block();
     NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:timeout];
-    [self XAT_waitUntilDate:loopUntil];
+    [self XCA_waitUntilDate:loopUntil];
     
     // Only assert when notified. Do not assert when timed out
     // Fail if not notified
@@ -111,13 +111,13 @@ static NSString * const kXCTestCaseAsyncTestingCategoryMethodPrefix = @"XAT_";
     
 }
 
-- (void)XAT_waitForStatus:(XCTAsyncTestCaseStatus)status timeout:(NSTimeInterval)timeout {
+- (void)XCA_waitForStatus:(XCTAsyncTestCaseStatus)status timeout:(NSTimeInterval)timeout {
     NSParameterAssert(timeout > 0);
     
     self._notified = NO;
     self._expectedStatus = status;
     NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:timeout];
-    [self XAT_waitUntilDate:loopUntil];
+    [self XCA_waitUntilDate:loopUntil];
     
     // Only assert when notified. Do not assert when timed out
     // Fail if not notified
@@ -148,7 +148,7 @@ static NSString * const kXCTestCaseAsyncTestingCategoryMethodPrefix = @"XAT_";
     
 }
 
-- (void)XAT_waitUntilDate:(NSDate *)date {
+- (void)XCA_waitUntilDate:(NSDate *)date {
     NSParameterAssert(date);
     NSParameterAssert([date compare: [NSDate date]] == NSOrderedDescending);
     
@@ -160,28 +160,28 @@ static NSString * const kXCTestCaseAsyncTestingCategoryMethodPrefix = @"XAT_";
     }
 }
 
-- (void)XAT_waitForTimeout:(NSTimeInterval)timeout {
+- (void)XCA_waitForTimeout:(NSTimeInterval)timeout {
     NSParameterAssert(timeout > 0);
     
     self._notified = NO;
     self._expectedStatus = XCTAsyncTestCaseStatusUnknown;
     NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:timeout];
-    [self XAT_waitUntilDate:loopUntil];
+    [self XCA_waitUntilDate:loopUntil];
 }
 
-- (void)XAT_notify:(XCTAsyncTestCaseStatus)status {
+- (void)XCA_notify:(XCTAsyncTestCaseStatus)status {
     
     self._notifiedStatus = status;
     // self.notified must be set at the last of this method
     self._notified = YES;
 }
 
-- (void)XAT_notify:(XCTAsyncTestCaseStatus)status withDelay:(NSTimeInterval)delay {
+- (void)XCA_notify:(XCTAsyncTestCaseStatus)status withDelay:(NSTimeInterval)delay {
     NSParameterAssert(delay > 0);
 
     __weak typeof(self) weakSelf = self;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        [weakSelf XAT_notify:status];
+        [weakSelf XCA_notify:status];
     });
     
 }

--- a/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.m
+++ b/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.m
@@ -72,10 +72,8 @@ static NSString * const kXCTestCaseAsyncTestingCategoryMethodPrefix = @"XAT_";
     NSParameterAssert(originalSelector);
     
     NSString *originalSelectorString = NSStringFromSelector(originalSelector);
-    //if ([originalSelectorString hasPrefix:@"_"] || [originalSelectorString hasPrefix:@"init"]) return NO;
+    if ([originalSelectorString hasPrefix:@"_"] || [originalSelectorString hasPrefix:@"init"]) return NO;
 
-
-    
     BOOL methodWasSuccessfullyAdded = NO;
     if (![originalSelectorString hasPrefix: kXCTestCaseAsyncTestingCategoryMethodPrefix ]) {
         

--- a/AsyncXCTestingKit/AsyncXCTestingKitTests/AsyncXCTestingKitTests.m
+++ b/AsyncXCTestingKit/AsyncXCTestingKitTests/AsyncXCTestingKitTests.m
@@ -93,7 +93,7 @@
 {
     
     __block BOOL canceled = NO;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         XCTAssertTrue(canceled, @"the async operation wasnt canceled");
     });
     


### PR DESCRIPTION
Hi,

i recently added the shorthand support, that we discussed in https://github.com/premosystems/XCAsyncTestCase/issues/5 . I chose the `XAT_` prefix, but im not quite sure if this prefix is the best.

Just let me know if you have any changes.
Cheers
