### PR TITLE
Fixes a typo in pragma to fix warning

### DIFF
--- a/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.m
+++ b/AsyncXCTestingKit/AsyncXCTestingKit/XCTestCase+AsyncTesting.m
@@ -63,7 +63,7 @@ static void *kExpectedStatus_Key = "kExpectedStatus_Key";
     self.notified = YES;
 }
 
-#pragma nark - Object Association Helpers -
+#pragma mark - Object Association Helpers -
 
 - (void) setAssociatedObject:(id)anObject key:(void*)key
 {


### PR DESCRIPTION
Sorry the tiny pull request, but this yields a warning under -Wall. 
